### PR TITLE
Default home-delivery location and strip stray text from Økoskabet notes

### DIFF
--- a/functions/functions.php
+++ b/functions/functions.php
@@ -679,6 +679,7 @@ function my_custom_checkout_field_display_admin_order_meta($order): void
 	$delivery_date = $order->get_meta('_billing_okoskabet_delivery_date', true);
 	$delivery_location = $order->get_meta('_billing_okoskabet_delivery_location', true);
 	$delivery_note = $order->get_meta('_billing_okoskabet_delivery_note', true);
+	$delivery_location_source = $order->get_meta('_billing_okoskabet_delivery_location_source', true);
 
 	// Resolve the merchant that fulfilled the order. `resolve_for_order`
 	// prefers the stored stamp written at checkout, and only falls back
@@ -720,7 +721,13 @@ function my_custom_checkout_field_display_admin_order_meta($order): void
 		echo esc_html__('Økoskabet Delivery location', O_TEXTDOMAIN) . ': ' . esc_html($delivery_location) . "\n";
 	}
 	if (!empty($delivery_note)) {
-		echo esc_html__('Note to driver', O_TEXTDOMAIN) . ': ' . esc_html($delivery_note);
+		echo esc_html__('Note to driver', O_TEXTDOMAIN) . ': ' . esc_html($delivery_note) . "\n";
+	}
+	if (!empty($delivery_location_source)) {
+		// Tells us per-order which checkout path produced the location:
+		// dropdown / andet_text / default_fallback. Useful for triaging
+		// the rate at which the JS UI fails to render in the wild.
+		echo esc_html__('Location source', O_TEXTDOMAIN) . ': ' . esc_html($delivery_location_source);
 	}
 	echo '</pre>';
 }
@@ -841,7 +848,13 @@ function hey_after_order_placed(int $order_id, string $old_status, string $new_s
 				'phone' => $order->get_billing_phone(),
 				'email' => $order->get_billing_email(),
 			],
-			'notes' => (string) $order->get_customer_note(),
+			// Shed deliveries: send empty notes. WooCommerce's customer_note
+			// field is a free-text bucket the customer fills with anything
+			// (subscription requests, city names, gift messages, etc.) and
+			// none of that is actionable for the driver placing the order in
+			// the shed. The reservation itself plus shed_id carries all the
+			// logistics info needed.
+			'notes' => '',
 			'delivery_date' => $order_delivery_date,
 			'reservation' => [
 				'shed_id' => $order_shed,
@@ -868,9 +881,13 @@ function hey_after_order_placed(int $order_id, string $old_status, string $new_s
 				'location' => !empty($logistics_note) ? $logistics_note : null,
 			]),
 			// Send the logistics note (dropdown selection + free-text) as the API
-			// notes field so it appears in Økoskabet's Notes column. Falls back to
-			// the standard WooCommerce customer note when no logistics note is set.
-			'notes' => !empty($logistics_note) ? $logistics_note : (string) $order->get_customer_note(),
+			// notes field so it appears in Økoskabet's Notes column. Do NOT fall
+			// back to the standard WooCommerce customer note — that field
+			// contaminates the logistics export with city names, subscription
+			// requests, and other unrelated text the driver can't act on.
+			// Only the explicit dropdown choice or the Andet free-text belongs
+			// here. An empty string is preferable to noise.
+			'notes' => $logistics_note,
 			'delivery_date' => $order_delivery_date,
 		];
 
@@ -938,6 +955,89 @@ function okoskabet_woocommerce_plugin_clear_shed_id_for_home_delivery($order, $d
 	if (in_array('hey_okoskabet_shipping_home', $shipping_methods, true)) {
 		$order->update_meta_data('_billing_okoskabet_shed_id', '');
 	}
+}
+
+/**
+ * Default the delivery location to "In front of the front door" when home
+ * delivery is selected and the customer didn't fill in either the dropdown
+ * or the free-text note. Covers the cases where our checkout JS never
+ * rendered (page cache, blocks-checkout, JS error, etc.) so the driver
+ * always receives a usable instruction instead of a blank line.
+ *
+ * Also stamps `_billing_okoskabet_delivery_location_source` so we can tell,
+ * per order, which path was taken (dropdown / andet_text / default_fallback).
+ * That stamp powers the admin metabox and the post-save log entry, and lets
+ * us aggregate root-cause signal over time without crawling the live
+ * checkout.
+ *
+ * Stored in English to match label_en values written by the dropdown UI;
+ * downstream localisation can happen on the driver-app side.
+ *
+ * NOTE: This hook fires BEFORE `$order->save()`, so `$order->get_id()`
+ * is still 0 here — that's why diagnostic logging is deferred to
+ * `woocommerce_checkout_order_processed` (below), where the saved
+ * order_id is finally available for correlation against the Økoskabet
+ * backend.
+ */
+add_action('woocommerce_checkout_create_order', 'okoskabet_woocommerce_plugin_default_delivery_location', 25, 2);
+
+function okoskabet_woocommerce_plugin_default_delivery_location($order, $data): void
+{
+	$shipping_methods = (array) ($data['shipping_method'] ?? array());
+	if (! in_array('hey_okoskabet_shipping_home', $shipping_methods, true)) {
+		return;
+	}
+
+	$location = trim((string) $order->get_meta('_billing_okoskabet_delivery_location', true));
+	$note     = trim((string) $order->get_meta('_billing_okoskabet_delivery_note', true));
+
+	if ($location !== '') {
+		$source = 'dropdown';
+	} elseif ($note !== '') {
+		$source = 'andet_text';
+	} else {
+		$source = 'default_fallback';
+		$order->update_meta_data('_billing_okoskabet_delivery_location', 'In front of the front door');
+	}
+
+	$order->update_meta_data('_billing_okoskabet_delivery_location_source', $source);
+}
+
+/**
+ * Companion to the create_order handler above: after the order has been
+ * persisted and we finally have a real order ID, log the diagnostic line
+ * for orders where our PHP default kicked in. We log here (not in the
+ * create_order handler) because `woocommerce_checkout_create_order` fires
+ * BEFORE `$order->save()` so the ID is 0 at that point — useless for
+ * cross-referencing against Økoskabet's backend.
+ *
+ * Keeping the data minimal: UA (truncated), postcode, login state.
+ * Enough to spot patterns (e.g. "always mobile Safari", "always guest",
+ * "always a specific postcode cluster") without dumping PII into the log.
+ */
+add_action('woocommerce_checkout_order_processed', 'okoskabet_woocommerce_plugin_log_default_fallback', 10, 1);
+
+function okoskabet_woocommerce_plugin_log_default_fallback(int $order_id): void
+{
+	$order = wc_get_order($order_id);
+	if (! $order instanceof \WC_Order) {
+		return;
+	}
+	$source = (string) $order->get_meta('_billing_okoskabet_delivery_location_source', true);
+	if ($source !== 'default_fallback') {
+		return;
+	}
+
+	$ua       = isset($_SERVER['HTTP_USER_AGENT']) ? substr((string) $_SERVER['HTTP_USER_AGENT'], 0, 200) : '';
+	$postcode = (string) $order->get_shipping_postcode();
+	$guest    = is_user_logged_in() ? 'member' : 'guest';
+	error_log(sprintf(
+		'okoskabet_woocommerce_plugin: delivery_location default_fallback order_id=%d postcode=%s user=%s ua=%s',
+		$order_id,
+		$postcode,
+		$guest,
+		$ua
+	));
 }
 
 /**

--- a/functions/functions.php
+++ b/functions/functions.php
@@ -958,33 +958,20 @@ function okoskabet_woocommerce_plugin_clear_shed_id_for_home_delivery($order, $d
 }
 
 /**
- * Default the delivery location to "In front of the front door" when home
- * delivery is selected and the customer didn't fill in either the dropdown
- * or the free-text note. Covers the cases where our checkout JS never
- * rendered (page cache, blocks-checkout, JS error, etc.) so the driver
- * always receives a usable instruction instead of a blank line.
+ * Stamp the delivery-location source and apply a default when neither
+ * the dropdown nor the Andet free-text was set on a home-delivery order.
  *
- * Also stamps `_billing_okoskabet_delivery_location_source` so we can tell,
- * per order, which path was taken (dropdown / andet_text / default_fallback).
- * That stamp powers the admin metabox and the post-save log entry, and lets
- * us aggregate root-cause signal over time without crawling the live
- * checkout.
- *
- * Stored in English to match label_en values written by the dropdown UI;
- * downstream localisation can happen on the driver-app side.
- *
- * NOTE: This hook fires BEFORE `$order->save()`, so `$order->get_id()`
- * is still 0 here — that's why diagnostic logging is deferred to
- * `woocommerce_checkout_order_processed` (below), where the saved
- * order_id is finally available for correlation against the Økoskabet
- * backend.
+ * Source values feed the admin metabox and the post-save diagnostic
+ * log; the default ensures the driver always has a usable instruction
+ * even when our checkout JS never rendered (page cache, blocks-checkout,
+ * mobile timing, etc.). Runs pre-save — `get_id()` would be 0 here, so
+ * logging lives in the post-save companion below.
  */
 add_action('woocommerce_checkout_create_order', 'okoskabet_woocommerce_plugin_default_delivery_location', 25, 2);
 
 function okoskabet_woocommerce_plugin_default_delivery_location($order, $data): void
 {
-	$shipping_methods = (array) ($data['shipping_method'] ?? array());
-	if (! in_array('hey_okoskabet_shipping_home', $shipping_methods, true)) {
+	if (! in_array('hey_okoskabet_shipping_home', (array) ($data['shipping_method'] ?? array()), true)) {
 		return;
 	}
 
@@ -1004,16 +991,10 @@ function okoskabet_woocommerce_plugin_default_delivery_location($order, $data): 
 }
 
 /**
- * Companion to the create_order handler above: after the order has been
- * persisted and we finally have a real order ID, log the diagnostic line
- * for orders where our PHP default kicked in. We log here (not in the
- * create_order handler) because `woocommerce_checkout_create_order` fires
- * BEFORE `$order->save()` so the ID is 0 at that point — useless for
- * cross-referencing against Økoskabet's backend.
- *
- * Keeping the data minimal: UA (truncated), postcode, login state.
- * Enough to spot patterns (e.g. "always mobile Safari", "always guest",
- * "always a specific postcode cluster") without dumping PII into the log.
+ * Log default_fallback events post-save, so order_id is non-zero and
+ * correlatable with the Økoskabet backend. UA + postcode + login state
+ * is enough to spot patterns (mobile Safari, guest-only, postcode
+ * cluster) without dumping PII.
  */
 add_action('woocommerce_checkout_order_processed', 'okoskabet_woocommerce_plugin_log_default_fallback', 10, 1);
 
@@ -1023,19 +1004,16 @@ function okoskabet_woocommerce_plugin_log_default_fallback(int $order_id): void
 	if (! $order instanceof \WC_Order) {
 		return;
 	}
-	$source = (string) $order->get_meta('_billing_okoskabet_delivery_location_source', true);
-	if ($source !== 'default_fallback') {
+	if ($order->get_meta('_billing_okoskabet_delivery_location_source', true) !== 'default_fallback') {
 		return;
 	}
 
-	$ua       = isset($_SERVER['HTTP_USER_AGENT']) ? substr((string) $_SERVER['HTTP_USER_AGENT'], 0, 200) : '';
-	$postcode = (string) $order->get_shipping_postcode();
-	$guest    = is_user_logged_in() ? 'member' : 'guest';
+	$ua = isset($_SERVER['HTTP_USER_AGENT']) ? substr((string) $_SERVER['HTTP_USER_AGENT'], 0, 200) : '';
 	error_log(sprintf(
 		'okoskabet_woocommerce_plugin: delivery_location default_fallback order_id=%d postcode=%s user=%s ua=%s',
 		$order_id,
-		$postcode,
-		$guest,
+		$order->get_shipping_postcode(),
+		is_user_logged_in() ? 'member' : 'guest',
 		$ua
 	));
 }


### PR DESCRIPTION
## Summary

Two related fixes for delivery-info reliability:

- **Default home-delivery location** to `"In front of the front door"` when the customer didn't fill in either the dropdown or the Andet free-text at checkout. Catches all the cases where our JS UI didn't render (page cache, blocks-checkout interaction, JS errors, mobile timing) so the driver always gets a usable instruction.
- **Stop leaking WC `customer_note` into the Økoskabet shipment payload**, for both home and shed deliveries. That field was used as a fallback when no logistics_note was present — but customers put gift messages, subscription requests, and city names there, none of which the driver can act on. Only explicit dropdown choice / Andet free-text is sent now; sheds send empty `notes` (the reservation+shed_id carries the logistics info).

Adds source tracking via `_billing_okoskabet_delivery_location_source` with values `dropdown` / `andet_text` / `default_fallback`, surfaced in the admin order metabox and logged to error_log for fallback events.

## Why

Empirically from the 2026-05-26 logistics export (523 unique orders):

| Path | Orders | % |
|---|---|---|
| Dropdown selected | 87 | 16.6% |
| Free text | 230 | 44.0% |
| Address-suffix only | 20 | 3.8% |
| Completely empty | 186 | 35.6% |

36% of orders arrived at Økoskabet with no logistics info at all. The "free text" bucket was also contaminated by `customer_note` leakage (cities, subscription notes). This PR ensures both columns are clean going forward.

## Implementation notes

- The PHP fallback runs on `woocommerce_checkout_create_order` (priority 25, after existing handlers).
- Diagnostic logging is split to `woocommerce_checkout_order_processed` because `create_order` fires *before* `$order->save()` — so `$order->get_id()` would be 0 at create-order time, breaking log correlation against the Økoskabet backend.
- Existing dropdown/Andet flows are not touched — they continue exactly as before.
- Programmatic order creation (subscription renewals, admin "Add order", REST API) doesn't trigger `woocommerce_checkout_create_order` and is therefore not covered by the default. Acceptable for now since Avokado isn't using those flows.

## Test plan

- [ ] Place a home-delivery order, leave the dropdown on its default — verify metabox shows `Location source: dropdown` and `Delivery location: In front of the front door`
- [ ] Place a home-delivery order, select "Andet" + type a note — verify metabox shows `Location source: andet_text` and the note appears under `Note to driver`
- [ ] Simulate JS failure (disable JS in DevTools) and submit a home-delivery order — verify metabox shows `Location source: default_fallback` and `Delivery location: In front of the front door`, plus an `okoskabet_woocommerce_plugin: delivery_location default_fallback` line in `wp-content/debug.log`
- [ ] Verify the Økoskabet shipment payload for a shed order has empty `notes` (not the customer's order note)
- [ ] Verify the Økoskabet shipment payload for a home order has `notes` and `home_delivery.location` matching the dropdown/Andet/default value with no customer_note contamination

## Follow-ups (separate PRs)

- UI styling refresh — the current dropdown and note input use inline styles and a `<tr>/<th>/<td>` structure that doesn't blend with custom checkout themes (visible on Avokadokontoret)
- Per-merchant default value (filter-based or pulled from `delivery_location_options` cache) once a merchant arrives whose options don't include "In front of the front door"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
